### PR TITLE
Update dependencies, drop support for python <3.8

### DIFF
--- a/.github/workflows/build-tests.yml
+++ b/.github/workflows/build-tests.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.6, 3.7, 3.8, 3.9]
+        python-version: [3.8, 3.9]
 
     steps:
     - uses: actions/checkout@v2

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-numpy==1.19.5
-pandas==1.1.5
-matplotlib==3.3.4
+numpy==1.22.3
+pandas==1.4.2
+matplotlib==3.5.2
 seaborn==0.10.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-numpy==1.22.3
-pandas==1.4.2
-matplotlib==3.5.2
-seaborn==0.10.1
+numpy>=1.21.0,<1.24.0
+pandas<1.5.0
+matplotlib<4.0.0
+seaborn<0.11.0

--- a/setup.py
+++ b/setup.py
@@ -23,10 +23,10 @@ setup(
     include_package_data=True,
     python_requires='>=3.6',
     install_requires=[
-        'numpy==1.19.5',
-        'pandas==1.1.5',
-        'matplotlib==3.3.4',
-        'seaborn==0.10.1'
+        'numpy==1.22.3',
+        'pandas==1.4.2',
+        'matplotlib==3.5.2',
+        'seaborn==0.10.1',
     ],
     classifiers=[
         'Development Status :: 3 - Alpha',

--- a/setup.py
+++ b/setup.py
@@ -23,10 +23,10 @@ setup(
     include_package_data=True,
     python_requires='>=3.8',
     install_requires=[
-        'numpy==1.22.3',
-        'pandas==1.4.2',
-        'matplotlib==3.5.2',
-        'seaborn==0.10.1',
+        'numpy>=1.21.0,<1.24.0',
+        'pandas<1.5.0',
+        'matplotlib<4.0.0',
+        'seaborn<0.11.0',
     ],
     classifiers=[
         'Development Status :: 3 - Alpha',

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ setup(
     download_url='https://github.com/bakermoran/BayesABTest/archive/v1.0.8-alpha.tar.gz',
     packages=['BayesABTest'],
     include_package_data=True,
-    python_requires='>=3.6',
+    python_requires='>=3.8',
     install_requires=[
         'numpy==1.22.3',
         'pandas==1.4.2',
@@ -33,7 +33,7 @@ setup(
         'Intended Audience :: Science/Research',
         'Topic :: Scientific/Engineering :: Mathematics',
         'License :: OSI Approved :: MIT License',
-        'Programming Language :: Python :: 3.6',
-        'Programming Language :: Python :: 3.7'
+        'Programming Language :: Python :: 3.8',
+        'Programming Language :: Python :: 3.9'
     ],
 )


### PR DESCRIPTION
# What? 
Bumping dependencies versions to their latest versions:
- numpy from `1.19.5` to `1.22.3`
- pandas from `1.1.5` to `1.4.2`
- matplotlib from `3.3.4` to `3.5.2`

Incidentally drops support for python 3.6 & 3.7 

# Why?
The current version of the dependencies are from over ~1.5 years ago (around Jan 2021)
Working with this module in combination with other up-to-date modules is getting increasingly difficult as the last year has seen some significant changes in the Python ecosystem.

As far as python versions are concerned, numpy has dropped support for:
  - Python 3.6 in 1.20.0 (~ Jan. 2021)
  - Python 3.7 in 1.22.0 (~ Dec. 2021)

Python 3.8 itself was released in Oct. 2019 and the current industry standard seems to be 3.9 (eg: Debian stable currently ships with 3.9). With 3.10 around the corner, it seems reasonable to drop support for 3.6, and 3.7 as numpy did.

WDYT? 